### PR TITLE
fix: lookup should ignore system proxy

### DIFF
--- a/src/lookup/mod.rs
+++ b/src/lookup/mod.rs
@@ -19,9 +19,9 @@ pub enum Provider {
 }
 
 impl Provider {
-    pub fn new(cfg: &Config) -> Self {
+    pub fn new(cfg: &Config) -> Result<Self> {
         match cfg.lookup.as_ref() {
-            None | Some(LookupConfig::ICanHazIp) => Provider::ICanHazIp(ICanHazIp),
+            None | Some(LookupConfig::ICanHazIp) => Ok(Provider::ICanHazIp(ICanHazIp::new()?)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub struct AppContext {
 impl AppContext {
     pub fn new(cli: Cli) -> Result<Self> {
         let config = Config::load(cli.config.as_ref()).context("Unable to load config.")?;
-        let lookup = Provider::new(&config);
+        let lookup = Provider::new(&config).context("Unable to initialize lookup provider")?;
         let client = Client::new(&config.token)?;
         let id_cache = Arc::new(Mutex::new(IdCache::load().unwrap_or_default()));
         Ok(AppContext {


### PR DESCRIPTION
By default, [`reqwest` will honor system proxy settings](https://docs.rs/reqwest/0.10.10/reqwest/#proxies) but this is not appropriate during an IP address lookup, since it won't correctly report the host's IP address.